### PR TITLE
feat: add support for partner parameters

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
@@ -10,6 +10,7 @@ import com.adjust.sdk.AdjustInstance;
 import com.adjust.sdk.LogLevel;
 import com.adjust.sdk.OnAttributionChangedListener;
 import com.segment.analytics.Analytics;
+import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.Properties;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.BasePayload;
@@ -123,13 +124,16 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
 
   private ValueMap getPartnerParameters(TrackPayload trackPayload) {
     ValueMap partnerParametersValueMap = new ValueMap();
-    ValueMap integrations = trackPayload.integrations();
-    if (!isNullOrEmpty(integrations)) {
-      ValueMap adjustConfig = integrations.getValueMap("Adjust");
-      if (!isNullOrEmpty(adjustConfig)) {
-        ValueMap partnerParameters = adjustConfig.getValueMap("partnerParameters");
-        if (!isNullOrEmpty(partnerParameters)) {
-          partnerParametersValueMap = partnerParameters;
+    AnalyticsContext context = trackPayload.context();
+    if (!isNullOrEmpty(context)) {
+      ValueMap integrations = context.getValueMap("integrations");
+      if (!isNullOrEmpty(integrations)) {
+        ValueMap adjustConfig = integrations.getValueMap("Adjust");
+        if (!isNullOrEmpty(adjustConfig)) {
+          ValueMap partnerParameters = adjustConfig.getValueMap("partnerParameters");
+          if (!isNullOrEmpty(partnerParameters)) {
+            partnerParametersValueMap = partnerParameters;
+          }
         }
       }
     }

--- a/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
@@ -60,12 +60,23 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
     Context context = analytics.getApplication();
 
     // FPT-227 overwrite Adjust app token from build settings
-    int overwrittenAppTokenIdentifier = context != null && context.getResources() != null ? context.getResources().getIdentifier("AdjustAppKey","string",context.getPackageName()) : 0;
-    String overwrittenAppToken = overwrittenAppTokenIdentifier > 0 ? context.getResources().getString(overwrittenAppTokenIdentifier) : "";
-    String appToken = overwrittenAppToken.length() > 0 ? overwrittenAppToken : settings.getString("appToken");
-    this.isAppTokenOverriden = overwrittenAppToken.length() > 0 && !overwrittenAppToken.equals(settings.getString("appToken"));
+    int overwrittenAppTokenIdentifier =
+        context != null && context.getResources() != null
+            ? context
+                .getResources()
+                .getIdentifier("AdjustAppKey", "string", context.getPackageName())
+            : 0;
+    String overwrittenAppToken =
+        overwrittenAppTokenIdentifier > 0
+            ? context.getResources().getString(overwrittenAppTokenIdentifier)
+            : "";
+    String appToken =
+        overwrittenAppToken.length() > 0 ? overwrittenAppToken : settings.getString("appToken");
+    this.isAppTokenOverriden =
+        overwrittenAppToken.length() > 0
+            && !overwrittenAppToken.equals(settings.getString("appToken"));
     this.appToken = appToken;
-    
+
     boolean setEnvironmentProduction = settings.getBoolean("setEnvironmentProduction", false);
     String environment = setEnvironmentProduction ? ENVIRONMENT_PRODUCTION : ENVIRONMENT_SANDBOX;
     AdjustConfig adjustConfig = new AdjustConfig(context, appToken, environment);

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -2,6 +2,8 @@ package com.segment.analytics.android.integrations.adjust;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.res.Resources;
+
 import com.adjust.sdk.Adjust;
 import com.adjust.sdk.AdjustAttribution;
 import com.adjust.sdk.AdjustConfig;
@@ -54,6 +56,8 @@ public class AdjustIntegrationTest {
   @Mock Analytics analytics;
   @Mock AdjustConfig config;
   @Mock AdjustInstance adjustInstance;
+  @Mock Application mockApplication;
+  @Mock Resources mockResources;
   AdjustIntegration integration;
 
   @Before public void setUp() {
@@ -62,6 +66,11 @@ public class AdjustIntegrationTest {
     ShadowLog.stream = System.out;
 
     when(analytics.logger("Adjust")).thenReturn(Logger.with(VERBOSE));
+    /*when(analytics.getApplication()).thenReturn(mockApplication);
+    when(mockApplication.getResources()).thenReturn(mockResources);
+    when(mockApplication.getPackageName()).thenReturn("testPackage");
+    when(mockResources.getIdentifier("AdjustAppKey", "string", "testPackage")).thenReturn(123456);
+    when(mockResources.getString(123456)).thenReturn("123456");*/
     ValueMap settings = new ValueMap() //
         .putValue("customEvents", new ValueMap().putValue("foo", "bar"));
 
@@ -248,7 +257,7 @@ public class AdjustIntegrationTest {
 
   @Test public void trackWithPartnerParameter() throws Exception {
     AdjustEvent event = mock(AdjustEvent.class);
-    PowerMockito.whenNew(AdjustEvent.class).withArguments("submissionSuccess").thenReturn(event);
+    PowerMockito.whenNew(AdjustEvent.class).withArguments("bar").thenReturn(event);
 
     ValueMap partnerParametersConfig = new ValueMap();
     partnerParametersConfig.put("event_id", "12345");
@@ -260,7 +269,7 @@ public class AdjustIntegrationTest {
     integrationOptions.setIntegrationOptions("Adjust", adjustConfig);
 
     integration.track(new TrackPayloadBuilder()
-            .event("submissionSuccess")
+            .event("foo")
             .options(integrationOptions)
             .build());
 

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -10,6 +10,7 @@ import com.adjust.sdk.AdjustInstance;
 import com.adjust.sdk.LogLevel;
 import com.adjust.sdk.OnAttributionChangedListener;
 import com.segment.analytics.Analytics;
+import com.segment.analytics.Options;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
@@ -242,6 +243,28 @@ public class AdjustIntegrationTest {
 
     verify(event).addCallbackParameter("type", "1");
     verify(event).addCallbackParameter("category", "shirt");
+    verify(adjustInstance).trackEvent(event);
+  }
+
+  @Test public void trackWithPartnerParameter() throws Exception {
+    AdjustEvent event = mock(AdjustEvent.class);
+    PowerMockito.whenNew(AdjustEvent.class).withArguments("submissionSuccess").thenReturn(event);
+
+    ValueMap partnerParametersConfig = new ValueMap();
+    partnerParametersConfig.put("event_id", "12345");
+
+    ValueMap adjustConfig = new ValueMap();
+    adjustConfig.put("partnerParameters", partnerParametersConfig);
+
+    Options integrationOptions = new Options();
+    integrationOptions.setIntegrationOptions("Adjust", adjustConfig);
+
+    integration.track(new TrackPayloadBuilder()
+            .event("submissionSuccess")
+            .options(integrationOptions)
+            .build());
+
+    verify(event).addPartnerParameter("event_id", "12345");
     verify(adjustInstance).trackEvent(event);
   }
 

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -66,11 +66,6 @@ public class AdjustIntegrationTest {
     ShadowLog.stream = System.out;
 
     when(analytics.logger("Adjust")).thenReturn(Logger.with(VERBOSE));
-    /*when(analytics.getApplication()).thenReturn(mockApplication);
-    when(mockApplication.getResources()).thenReturn(mockResources);
-    when(mockApplication.getPackageName()).thenReturn("testPackage");
-    when(mockResources.getIdentifier("AdjustAppKey", "string", "testPackage")).thenReturn(123456);
-    when(mockResources.getString(123456)).thenReturn("123456");*/
     ValueMap settings = new ValueMap() //
         .putValue("customEvents", new ValueMap().putValue("foo", "bar"));
 

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -12,11 +12,10 @@ import com.adjust.sdk.AdjustInstance;
 import com.adjust.sdk.LogLevel;
 import com.adjust.sdk.OnAttributionChangedListener;
 import com.segment.analytics.Analytics;
-import com.segment.analytics.Options;
+import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
-import com.segment.analytics.android.integrations.adjust.AdjustIntegration.SegmentAttributionChangedListener;
 import com.segment.analytics.core.tests.BuildConfig;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.test.TrackPayloadBuilder;
@@ -36,6 +35,7 @@ import org.robolectric.shadows.ShadowLog;
 
 import static com.segment.analytics.Analytics.LogLevel.NONE;
 import static com.segment.analytics.Analytics.LogLevel.VERBOSE;
+import static com.segment.analytics.Utils.createContext;
 import static com.segment.analytics.Utils.createTraits;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -265,12 +265,15 @@ public class AdjustIntegrationTest {
     ValueMap adjustConfig = new ValueMap();
     adjustConfig.put("partnerParameters", partnerParametersConfig);
 
-    Options integrationOptions = new Options();
-    integrationOptions.setIntegrationOptions("Adjust", adjustConfig);
+    ValueMap integrationsConfig = new ValueMap();
+    integrationsConfig.put("Adjust", adjustConfig);
+
+    AnalyticsContext context = createContext(createTraits());
+    context.put("integrations", integrationsConfig);
 
     integration.track(new TrackPayloadBuilder()
             .event("foo")
-            .options(integrationOptions)
+            .context(context)
             .build());
 
     verify(event).addPartnerParameter("event_id", "12345");


### PR DESCRIPTION
# Overview
We need to enable Partner Parameters in Adjust https://help.adjust.com/en/article/record-events-ios-sdk#add-partner-parameters

Reasons to add this:
- FB CAPI Event deduplication
- Start sending product catalog info to networks

We will use the `integrations` object (sent in `context` for enabling sending this special parameters back to Adjust)

ie: 
```
{
  "context": {
     "integrations": {
      "Adjust": {
        "partnerParameters": {
          "event_id": 12345,
        }
      }
    }
  }
}
```

Note: this will require changes in the tracking plugin of segment in the new tracking library.